### PR TITLE
fix: add b2c-backend network alias for cross-container DNS resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@
 ## Provides multi-network support so the backend can reach both
 ## the Coolify proxy (coolify network) and Supabase DB (supabase network).
 ##
-## USAGE: In Coolify, switch build pack from "Dockerfile" to "Docker Compose"
-##        and enable "Is Raw Compose Deployment Enabled" in Advanced settings.
+## USAGE: In Coolify, switch build pack from "Dockerfile" to "Docker Compose".
+##        Do NOT enable raw compose mode — let Coolify inject Traefik labels.
 ##        Environment variables are injected by Coolify into .env file.
 
 services:
@@ -16,8 +16,10 @@ services:
     expose:
       - "5000"
     networks:
-      - coolify
-      - supabase
+      coolify:
+        aliases:
+          - b2c-backend
+      supabase:
     env_file:
       - .env
     healthcheck:


### PR DESCRIPTION
### **User description**
The frontend (API_BASE_URL=http://b2c-backend:5000) and RAG pipeline (ALLOWED_ORIGINS=http://b2c-backend:5000) containers reference the backend by the hostname 'b2c-backend'. Without this alias, Docker DNS won't resolve the hostname and SSR API calls / CORS will break.

Also updates header comment to reflect non-raw compose mode usage.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `b2c-backend` network alias for DNS resolution

- Update usage comment to disable raw compose mode


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add network alias and update usage instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Updated USAGE comment to disable raw compose mode<br> <li> Added <code>aliases: ["b2c-backend"]</code> under <code>coolify</code> network<br> <li> Removed separate network list in <code>networks</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/16/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

