### PR TITLE
fix: switch to raw compose mode with explicit Traefik labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,14 @@
-## ---------- Docker Compose for Coolify Deployment ----------
+## ---------- Docker Compose for Coolify Deployment (Raw Mode) ----------
 ## Provides multi-network support so the backend can reach both
 ## the Coolify proxy (coolify network) and Supabase DB (supabase network).
 ##
-## USAGE: In Coolify, switch build pack from "Dockerfile" to "Docker Compose".
-##        Do NOT enable raw compose mode — let Coolify inject Traefik labels.
+## USAGE: In Coolify, switch build pack from "Dockerfile" to "Docker Compose"
+##        and ENABLE "Is Raw Compose Deployment Enabled" in Advanced settings.
+##        Raw mode is REQUIRED — non-raw mode strips our supabase network.
 ##        Environment variables are injected by Coolify into .env file.
+##
+## NOTE: Traefik labels are explicitly declared because raw mode does not
+##       auto-inject them. Update the Host rules if the domain changes.
 
 services:
   backend:
@@ -28,6 +32,24 @@ services:
       timeout: 5s
       start_period: 15s
       retries: 3
+    labels:
+      # ── Coolify Management ──
+      coolify.managed: "true"
+      # ── Traefik HTTP Routing ──
+      traefik.enable: "true"
+      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.entrypoints: http
+      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.rule: Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)
+      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.service: http-0-occoo80co04cw40kcoo40o8s
+      traefik.http.services.http-0-occoo80co04cw40kcoo40o8s.loadbalancer.server.port: "5000"
+      # ── Traefik HTTPS Routing ──
+      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.entrypoints: https
+      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.rule: Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)
+      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.service: http-0-occoo80co04cw40kcoo40o8s
+      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls: "true"
+      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls.certresolver: letsencrypt
+      # ── Caddy Fallback ──
+      caddy_0: http://occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io
+      caddy_0.handle_path.0_reverse_proxy: "{{upstreams 5000}}"
 
 networks:
   coolify:


### PR DESCRIPTION
### **User description**
Non-raw compose mode confirmed to strip our supabase external network declaration, replacing it with Coolify's own project network. This caused the backend to lose DB connectivity and enter a restart loop.

Raw mode uses the compose file as-is, preserving both external network declarations. Traefik labels are explicitly declared since raw mode does not auto-inject them.

Labels sourced from the existing Coolify App 66 configuration.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Require raw compose mode to preserve external networks

- Add explicit Traefik HTTP/HTTPS routing labels

- Include Caddy fallback proxy label

- Update usage instructions in comments


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add raw mode requirement and routing labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Updated header comments to enable raw mode<br> <li> Added Traefik labels for HTTP and HTTPS routers<br> <li> Added Caddy fallback proxy label</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/17/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

