### PR TITLE
fix: switch labels from map format to list format for Coolify compati…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,22 +34,22 @@ services:
       retries: 3
     labels:
       # ── Coolify Management ──
-      coolify.managed: "true"
+      - "coolify.managed=true"
       # ── Traefik HTTP Routing ──
-      traefik.enable: "true"
-      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.entrypoints: http
-      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.rule: Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)
-      traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.service: http-0-occoo80co04cw40kcoo40o8s
-      traefik.http.services.http-0-occoo80co04cw40kcoo40o8s.loadbalancer.server.port: "5000"
+      - "traefik.enable=true"
+      - "traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.entrypoints=http"
+      - "traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.rule=Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)"
+      - "traefik.http.routers.http-0-occoo80co04cw40kcoo40o8s.service=http-0-occoo80co04cw40kcoo40o8s"
+      - "traefik.http.services.http-0-occoo80co04cw40kcoo40o8s.loadbalancer.server.port=5000"
       # ── Traefik HTTPS Routing ──
-      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.entrypoints: https
-      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.rule: Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)
-      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.service: http-0-occoo80co04cw40kcoo40o8s
-      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls: "true"
-      traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls.certresolver: letsencrypt
+      - "traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.entrypoints=https"
+      - "traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.rule=Host(`occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io`)"
+      - "traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.service=http-0-occoo80co04cw40kcoo40o8s"
+      - "traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls=true"
+      - "traefik.http.routers.https-0-occoo80co04cw40kcoo40o8s.tls.certresolver=letsencrypt"
       # ── Caddy Fallback ──
-      caddy_0: http://occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io
-      caddy_0.handle_path.0_reverse_proxy: "{{upstreams 5000}}"
+      - "caddy_0=http://occoo80co04cw40kcoo40o8s.207.244.226.234.sslip.io"
+      - "caddy_0.handle_path.0_reverse_proxy={{upstreams 5000}}"
 
 networks:
   coolify:


### PR DESCRIPTION
### **User description**
…bility

Coolify's raw parser (oldRawParser) injects its own labels in list format (0: key=value, 1: key=value). When merged with our map-format labels, the resulting YAML has numeric keys that Docker Compose rejects with 'non-string key in services.backend.labels'.

Switching to list format (- 'key=value') ensures clean merging.


___

### **PR Type**
Bug fix


___

### **Description**
- Convert service `labels` entries from map to list

- Ensure compatibility with Coolify labels injection

- Prevent non-string key errors in Docker Compose


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docker-compose.yml"] -- "map → list labels" --> B["Coolify compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use list-format labels for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Changed <code>labels</code> entries from <code>key: value</code> to <code>- "key=value"</code><br> <li> Updated Traefik HTTP/HTTPS routing labels to list format<br> <li> Converted Caddy fallback labels to list entries</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/18/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+13/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

