### PR TITLE
fix: prevent duplicate recipes across meal types

### DIFF
--- a/server/services/mealPlan.ts
+++ b/server/services/mealPlan.ts
@@ -301,64 +301,135 @@ async function fetchRecipeCatalog(params: {
 
 // ── Graph-Scored Recipe Candidates (PRD-12) ─────────────────────────────────
 
+const MEAL_TYPE_ORDER: Record<string, number> = {
+  breakfast: 0,
+  lunch: 1,
+  dinner: 2,
+  snack: 3,
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function mapRagCandidates(
+  candidates: any[],
+  mealTypeOverride?: string | null
+): RecipeOption[] {
+  return candidates.map((c: any) => ({
+    id: c.recipe_id,
+    title: c.title,
+    mealType: mealTypeOverride ?? c.meal_type ?? null,
+    cuisine: c.cuisine ?? null,
+    calories: c.calories ?? 0,
+    proteinG: c.protein_g ?? 0,
+    carbsG: c.carbs_g ?? 0,
+    fatG: c.fat_g ?? 0,
+    cookTimeMinutes: c.cook_time_minutes ?? null,
+    allergens: c.allergens ?? [],
+    diets: c.diets ?? [],
+    graphScore: c.score,
+    graphReasons: c.reasons,
+  }));
+}
+
 async function getRecipeCandidates(
   b2cCustomerId: string,
   members: MemberContext[],
-  params: { cuisineIds?: string[]; maxCookTime?: number; excludeIds: string[]; limit: number; memberDiets?: string[] },
+  params: { cuisineIds?: string[]; maxCookTime?: number; excludeIds: string[]; limit: number; memberDiets?: string[]; mealTypes?: string[] },
   householdType?: string,
   totalMembers?: number,
   householdId?: string,
   scope?: string,
   memberProfile?: Record<string, unknown>
 ): Promise<RecipeOption[]> {
-  // Try RAG-scored candidates first
-  const graphCandidates = await ragMealCandidates({
+  const mealTypes = params.mealTypes;
+  const ragMembers = members.map((m, i) => ({
+    id: `member-${i}`,
+    allergen_ids: m.allergens,
+    diet_ids: m.diets,
+    health_profile: {
+      calorie_target: m.calorieTarget,
+      protein_target_g: m.proteinTargetG,
+    },
+  }));
+
+  const ragBaseParams = {
     customer_id: b2cCustomerId,
-    members: members.map((m, i) => ({
-      id: `member-${i}`,
-      allergen_ids: m.allergens,
-      diet_ids: m.diets,
-      health_profile: {
-        calorie_target: m.calorieTarget,
-        protein_target_g: m.proteinTargetG,
-      },
-    })),
+    members: ragMembers,
     meal_history: params.excludeIds,
     date_range: { start: new Date().toISOString().slice(0, 10), end: new Date().toISOString().slice(0, 10) },
-    meals_per_day: ["breakfast", "lunch", "dinner"],
-    limit: params.limit,
+    meals_per_day: mealTypes ?? ["breakfast", "lunch", "dinner"],
     household_type: householdType,
     total_members: totalMembers,
     household_id: householdId,
     scope,
     member_profile: memberProfile,
-  });
+  };
 
-  if (graphCandidates && graphCandidates.candidates.length > 0) {
-    // Validate that candidate IDs are real UUIDs before using them
-    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    const hasValidIds = graphCandidates.candidates.every(
-      (c: any) => c.recipe_id && UUID_RE.test(c.recipe_id)
+  // If mealTypes is provided, call RAG per meal type in parallel to get scoped candidates
+  if (mealTypes && mealTypes.length > 0) {
+    const perMealType = await Promise.all(
+      mealTypes.map((mt) =>
+        ragMealCandidates({
+          ...ragBaseParams,
+          limit: Math.ceil(params.limit / mealTypes.length) + 10, // slightly more per type to allow crossover
+          meal_type: mt,
+        })
+      )
     );
 
-    if (hasValidIds) {
-      return graphCandidates.candidates.map((c: any) => ({
-        id: c.recipe_id,
-        title: c.title,
-        mealType: c.meal_type ?? null,
-        cuisine: c.cuisine ?? null,
-        calories: c.calories ?? 0,
-        proteinG: c.protein_g ?? 0,
-        carbsG: c.carbs_g ?? 0,
-        fatG: c.fat_g ?? 0,
-        cookTimeMinutes: c.cook_time_minutes ?? null,
-        allergens: c.allergens ?? [],
-        diets: c.diets ?? [],
-        graphScore: c.score,
-        graphReasons: c.reasons,
-      }));
-    } else {
-      logger.warn("[RAG] Meal candidates have non-UUID IDs, falling back to SQL catalog");
+    // Merge and deduplicate across meal types, keeping first occurrence per recipe ID
+    const seenIds = new Set<string>();
+    const merged: RecipeOption[] = [];
+
+    for (let i = 0; i < mealTypes.length; i++) {
+      const result = perMealType[i];
+      if (!result || result.candidates.length === 0) continue;
+      const hasValidIds = result.candidates.every(
+        (c: any) => c.recipe_id && UUID_RE.test(c.recipe_id)
+      );
+      if (!hasValidIds) {
+        logger.warn(`[RAG] Meal candidates for ${mealTypes[i]} have non-UUID IDs, skipping`);
+        continue;
+      }
+      const mapped = mapRagCandidates(result.candidates, mealTypes[i]);
+      for (const candidate of mapped) {
+        if (!seenIds.has(candidate.id)) {
+          seenIds.add(candidate.id);
+          merged.push(candidate);
+        }
+      }
+    }
+
+    if (merged.length > 0) {
+      // Deduplicate by ID, keeping highest graph score
+      const best = new Map<string, RecipeOption>();
+      for (const c of merged) {
+        const existing = best.get(c.id);
+        if (!existing || (c.graphScore ?? 0) > (existing.graphScore ?? 0)) {
+          best.set(c.id, c);
+        }
+      }
+      return Array.from(best.values()).slice(0, params.limit);
+    }
+
+    // All RAG calls failed or returned no valid IDs — fall through to SQL
+  } else {
+    // No mealTypes provided — single RAG call (legacy behavior for swap, etc.)
+    const graphCandidates = await ragMealCandidates({
+      ...ragBaseParams,
+      limit: params.limit,
+    });
+
+    if (graphCandidates && graphCandidates.candidates.length > 0) {
+      const hasValidIds = graphCandidates.candidates.every(
+        (c: any) => c.recipe_id && UUID_RE.test(c.recipe_id)
+      );
+
+      if (hasValidIds) {
+        return mapRagCandidates(graphCandidates.candidates);
+      } else {
+        logger.warn("[RAG] Meal candidates have non-UUID IDs, falling back to SQL catalog");
+      }
     }
   }
 
@@ -464,6 +535,7 @@ export async function generateMealPlan(
     excludeIds: allExcluded,
     limit: maxRecipes,
     memberDiets: allMemberDiets,
+    mealTypes: input.mealsPerDay,
   }, household.householdType ?? undefined, household.totalMembers ?? undefined,
      household.id, toRagScope(household.householdType), aggregatedProfile);
   let cuisineFallbackApplied = preferredCuisines.length > 0 && cuisineIds.length === 0;
@@ -475,6 +547,7 @@ export async function generateMealPlan(
       excludeIds: allExcluded,
       limit: maxRecipes,
       memberDiets: allMemberDiets,
+      mealTypes: input.mealsPerDay,
     }, household.householdType ?? undefined, household.totalMembers ?? undefined,
        household.id, toRagScope(household.householdType), aggregatedProfile);
     cuisineFallbackApplied = recipeCatalog.length > 0;
@@ -544,6 +617,24 @@ export async function generateMealPlan(
       (err as any).status = 422;
       throw err;
     }
+  }
+
+  // ── Deduplication: ensure each recipe appears at most once across the entire plan ──
+  // Keep earliest occurrence (earlier date → earlier meal slot: breakfast < lunch < dinner < snack)
+  const seenRecipeIds = new Set<string>();
+  const mealTypeOrder = MEAL_TYPE_ORDER;
+  validatedMeals = validatedMeals.sort((a, b) => {
+    if (a.date !== b.date) return a.date.localeCompare(b.date);
+    return (mealTypeOrder[a.mealType] ?? 99) - (mealTypeOrder[b.mealType] ?? 99);
+  });
+  const beforeDedup = validatedMeals.length;
+  validatedMeals = validatedMeals.filter((m) => {
+    if (seenRecipeIds.has(m.recipeId)) return false;
+    seenRecipeIds.add(m.recipeId);
+    return true;
+  });
+  if (beforeDedup !== validatedMeals.length) {
+    logger.info("[MealPlan] Deduplication removed", beforeDedup - validatedMeals.length, "duplicate recipe assignments");
   }
 
   const generationTimeMs = Date.now() - startTime;
@@ -893,7 +984,14 @@ export async function swapMeal(
     limit: 30,
   });
 
-  if (alternatives.length === 0) {
+  // Also exclude any recipes already in the plan that aren't the one being swapped out
+  const planRecipeIds = new Set(currentPlanRecipeIds);
+  const filteredAlternatives = alternatives.filter(
+    (a) => !planRecipeIds.has(a.id) || a.id === item.recipeId
+  );
+  const swappableAlternatives = filteredAlternatives.length > 0 ? filteredAlternatives : alternatives;
+
+  if (swappableAlternatives.length === 0 && alternatives.length === 0) {
     const err = new Error("No alternative recipes available");
     (err as any).status = 422;
     throw err;
@@ -918,11 +1016,11 @@ export async function swapMeal(
       mealDate: item.mealDate,
       mealType: item.mealType || "dinner",
       members,
-      alternatives,
+      alternatives: swappableAlternatives,
       swapReason: reason,
     });
   } catch (error: any) {
-    swapResult = buildRuleBasedSwapFallback(alternatives, item.recipeId, String(error?.message || "LLM unavailable"));
+    swapResult = buildRuleBasedSwapFallback(swappableAlternatives, item.recipeId, String(error?.message || "LLM unavailable"));
   }
 
   const newNutrition = await getRecipeNutrition(swapResult.recipeId);

--- a/server/services/mealPlanLLM.ts
+++ b/server/services/mealPlanLLM.ts
@@ -198,7 +198,7 @@ STRICT RULES (must NEVER be violated):
 2. ZERO allergen violations — if ANY family member is allergic to something, exclude ALL recipes containing that allergen
 3. Stay within the budget constraint if provided
 4. Meet each member's calorie/macro targets within ±10%
-5. No repeat recipes within the same week (unless fewer recipes than meal slots)
+5. Each recipe ID must appear at most ONCE in the entire plan — never assign the same recipe to different meal types or different days. If the candidate pool is smaller than the number of meal slots, only then may you repeat, and prefer maximum variety
 6. Balance variety across cuisines and meal types
 7. Respect cooking time constraints
 8. For each meal, estimate the grocery cost in the given currency


### PR DESCRIPTION
### **User description**
## Problem
Same recipe appears in both breakfast and dinner in generated meal plans.

## Root Cause
- `getRecipeCandidates()` called RAG once without `meal_type`, returning a flat undifferentiated pool
- LLM assigned recipes from this pool without meal-type discrimination
- Many recipes have `meal_type: null` in DB, giving the LLM no signal
- No dedup check after LLM response

## Changes

### `server/services/mealPlanLLM.ts`
- Strengthened Rule 5: each recipe ID must appear at most once across the entire plan

### `server/services/mealPlan.ts`
- **Per-meal-type RAG calls**: `getRecipeCandidates()` now calls `ragMealCandidates()` once per meal type via `Promise.all`, passing `meal_type` to scope retrieval
- **Candidate tagging**: Recipes are tagged with the meal type they were retrieved for (from request param, not nullable DB `meal_type`)
- **Dedup post-processing**: After LLM response, recipes are sorted by (date, meal slot order) and duplicates removed — keeping earliest occurrence
- **Swap endpoint dedup**: `swapMeal()` now filters alternatives to exclude recipes already in the plan (except the one being swapped)
- **Legacy fallback**: When no `mealTypes` provided (e.g. swap), falls back to single RAG call

## Testing
- Build passes
- Manual testing needed: generate a weekly plan with breakfast/lunch/dinner and verify no duplicate recipe IDs

## No Changes Required
- **Frontend**: `nutri-b2c` — no changes needed
- **RAG service**: Already supports `meal_type` parameter — just wasn't being called with it

Review: @victor


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Call RAG per meal type for scoped candidates

- Deduplicate plan by date and meal slot order

- Filter swap alternatives excluding existing plan recipes

- Strengthen LLM Rule 5 to forbid repeats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input meal types"] --> B["Per-meal-type RAG calls"]
  B --> C["Merge & deduplicate candidates"]
  C -- "No valid RAG IDs" --> D["SQL catalog fallback"]
  C --> E["Generate raw meal plan"]
  D --> E
  E --> F["Sort & remove duplicate recipes"]
  F --> G["Final meal plan"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mealPlan.ts</strong><dd><code>Add per-type RAG and dedupe logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/mealPlan.ts

<ul><li>Add <code>MEAL_TYPE_ORDER</code> and <code>UUID_RE</code> constants<br> <li> Introduce <code>mapRagCandidates</code> helper function<br> <li> Implement per-meal-type RAG calls and merge logic<br> <li> Post-generation dedup and swap alternative filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/21/files#diff-6edb627c49f193554055aeb58986bc7302800aa78a96ca4588393976eb25da0b">+139/-41</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mealPlanLLM.ts</strong><dd><code>Strengthen LLM Rule 5 for no repeats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/mealPlanLLM.ts

<ul><li>Update LLM prompt Rule 5 to forbid recipe repeats<br> <li> Clarify rule wording for variety constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/21/files#diff-c7a094789f5885b5f8f4dc706abd7bf2662ef66032f0ceb5c0e09ddc906aa9dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

