### PR TITLE
feat: add PATCH /households for plan intent + fix GET /profile to ret…

### DIFF
--- a/server/routes/household.ts
+++ b/server/routes/household.ts
@@ -63,6 +63,48 @@ const updateHealthSchema = z.object({
 
 // ── Routes ──────────────────────────────────────────────────────────────────
 
+const updateHouseholdTypeSchema = z.object({
+  householdType: z.enum(["individual", "couple", "family"]),
+});
+
+/**
+ * @openapi
+ * /households:
+ *   patch:
+ *     tags: [Household]
+ *     summary: Update household plan type
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [householdType]
+ *             properties:
+ *               householdType: { type: string, enum: [individual, couple, family] }
+ *     responses:
+ *       200: { description: Household type updated }
+ *       403: { description: Only primary_adult can change plan }
+ */
+router.patch(
+  "/",
+  rateLimitMiddleware,
+  requireHouseholdRole("primary_adult"),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const customerId = b2cId(req);
+      const { householdType } = updateHouseholdTypeSchema.parse(req.body);
+      const household = await getOrCreateHousehold(customerId);
+
+      const { updateHouseholdType } = await import("../services/household.js");
+      const updated = await updateHouseholdType(household.id, householdType);
+      res.json({ household: updated });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 /**
  * @openapi
  * /households/members:

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -139,13 +139,13 @@ router.get("/profile", authMiddleware, rateLimitMiddleware, async (req, res, nex
       phone: row.phone ?? null,
       dateOfBirth: row.date_of_birth ?? null,
       age: (() => {
-        // Prefer computing from date_of_birth for accuracy; fall back to stored age column
+        // Parse DOB as calendar date parts to avoid timezone shifts from new Date()
         if (row.date_of_birth) {
-          const dob = new Date(row.date_of_birth);
+          const [y, m, d] = String(row.date_of_birth).split("-").map(Number);
           const now = new Date();
-          let years = now.getFullYear() - dob.getFullYear();
-          const m = now.getMonth() - dob.getMonth();
-          if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) years--;
+          let years = now.getFullYear() - y;
+          const mNow = now.getMonth() + 1; // 1-indexed to match parsed month
+          if (mNow < m || (mNow === m && now.getDate() < d)) years--;
           return years;
         }
         return row.age ?? null;

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -134,10 +134,23 @@ router.get("/profile", authMiddleware, rateLimitMiddleware, async (req, res, nex
     res.json({
       id: row.id,
       fullName: row.full_name,
+      firstName: row.first_name ?? null,
       email: row.email,
-      phone: row.phone,
-      dateOfBirth: row.date_of_birth,
-      gender: row.gender,
+      phone: row.phone ?? null,
+      dateOfBirth: row.date_of_birth ?? null,
+      age: (() => {
+        // Prefer computing from date_of_birth for accuracy; fall back to stored age column
+        if (row.date_of_birth) {
+          const dob = new Date(row.date_of_birth);
+          const now = new Date();
+          let years = now.getFullYear() - dob.getFullYear();
+          const m = now.getMonth() - dob.getMonth();
+          if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) years--;
+          return years;
+        }
+        return row.age ?? null;
+      })(),
+      gender: row.gender ?? null,
       householdId: row.household_id,
       householdRole: row.household_role,
       isProfileOwner: row.is_profile_owner,

--- a/server/services/household.ts
+++ b/server/services/household.ts
@@ -73,6 +73,21 @@ export interface UpdateMemberHealthInput {
   cuisineIds?: string[];
 }
 
+// ── Update Household Type (plan intent) ─────────────────────────────────────
+
+export async function updateHouseholdType(
+  householdId: string,
+  householdType: "individual" | "couple" | "family"
+) {
+  const updated = await db
+    .update(households)
+    .set({ householdType })
+    .where(eq(households.id, householdId))
+    .returning();
+
+  return updated[0];
+}
+
 // ── Get or Create Household ─────────────────────────────────────────────────
 
 export async function getOrCreateHousehold(b2cCustomerId: string) {

--- a/server/services/household.ts
+++ b/server/services/household.ts
@@ -85,6 +85,9 @@ export async function updateHouseholdType(
     .where(eq(households.id, householdId))
     .returning();
 
+  if (updated.length === 0) {
+    throw Object.assign(new Error("Household not found"), { status: 404 });
+  }
   return updated[0];
 }
 


### PR DESCRIPTION
### **User description**
## feat: Add PATCH /households for Plan Intent + Fix GET /profile to Return Age & Phone

### Summary

Adds a new `PATCH /` endpoint on the household route for updating `household_type` (plan intent), and fixes the `GET /user/profile` endpoint to include the `age` field — which was present in the database but omitted from the response mapping.

---

### Changes

| File | Description |
|------|-------------|
| `server/routes/household.ts` | **New endpoint**: `PATCH /` — accepts `{ householdType: "individual" \| "couple" \| "family" }`. Validates via Zod enum. Requires `primary_adult` role. Calls `updateHouseholdType` service. |
| `server/services/household.ts` | **New function**: `updateHouseholdType(householdId, householdType)` — Drizzle `update().set().where().returning()`. |
| `server/routes/user.ts` | **Fix**: `GET /profile` response now includes `age` (computed dynamically from `date_of_birth` via birthday math, falls back to stored `age` column). Also added `firstName` and explicit `?? null` coalescing for `phone`, `dateOfBirth`, and `gender`. |

---

### Root Cause Analysis (Age/Phone Issue)

The `GET /user/profile` handler queries `c.*` from `gold.b2c_customers` (which contains both `phone` and `age` columns), but the response mapping at lines 134–149 explicitly enumerated only a subset of fields — **`age` was silently dropped**. The `phone` column was included but returned raw `undefined` when NULL instead of explicit `null`.

**Schema columns confirmed**:
- `gold.b2c_customers.phone` → `varchar(50)` ✅
- `gold.b2c_customers.date_of_birth` → `date` ✅
- `gold.b2c_customers.age` → `integer` ✅

**Fix**: Age is now computed from `date_of_birth` for accuracy (handles birthday boundary correctly). Falls back to the stored `age` integer if no DOB is present.

### API Contract

#### `PATCH /api/v1/households`

**Request:**
```json
{
  "householdType": "couple"
}


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add PATCH /households endpoint for plan intent

- Introduce updateHouseholdType service function

- Fix GET /user/profile: include age and firstName

- Coalesce phone, dateOfBirth, gender to null


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PATCH /households"] --> B["Validate body"]
  B --> C["Require primary_adult role"]
  C --> D["updateHouseholdType service"]
  D --> E["DB update households"]
  E --> F["Return updated household"]
  G["GET /user/profile"] --> H["Fetch profile row"]
  H --> I["Map fields & compute age"]
  I --> J["Return enhanced profile"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>household.ts</strong><dd><code>Add PATCH /households endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes/household.ts

<ul><li>Introduce <code>updateHouseholdTypeSchema</code> validation<br> <li> Add <code>PATCH /</code> route with <code>primary_adult</code> role guard<br> <li> Import and call <code>updateHouseholdType</code> service<br> <li> Add OpenAPI docs for new endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/27/files#diff-29fe909b4a69be076323753d27cf35e61539a9904c9d6e75c7a18f788095836d">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>household.ts</strong><dd><code>Implement updateHouseholdType service function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/household.ts

<ul><li>Add <code>updateHouseholdType</code> function with Drizzle ORM<br> <li> Update <code>householdType</code> and return updated record</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/27/files#diff-867c490ed00b10b5c7bdd0a48e49cf4c892d86b3d20aded8413223018479b5fb">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.ts</strong><dd><code>Fix profile API to return age and nulls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes/user.ts

<ul><li>Add <code>firstName</code> to response<br> <li> Coalesce <code>phone</code>, <code>dateOfBirth</code>, <code>gender</code> to null<br> <li> Compute <code>age</code> from <code>date_of_birth</code>, fallback to stored</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/27/files#diff-97a6fee2d27d48dae445c1c542a95441edf63ebddc1a7a4505e3f2aa72965718">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

