### PR TITLE
feat: trigger CI on develop/staging/main with per-env deploy

### DIFF
--- a/.github/workflows/b2c_backend-ci.yml
+++ b/.github/workflows/b2c_backend-ci.yml
@@ -2,9 +2,9 @@ name: B2C Backend CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop, staging]
   push:
-    branches: [main]
+    branches: [main, develop, staging]
   workflow_dispatch:
 
 concurrency:
@@ -37,13 +37,41 @@ jobs:
       build-args: ""
     secrets: inherit
 
-  deploy:
+  deploy-dev:
     needs: [docker-validate]
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     uses: ConferInc/CI-Pipeline/.github/workflows/reusable-cd-deploy.yml@main
     with:
       image-name: nutrition-backend
       context: .
       dockerfile: Dockerfile
       build-args: ""
-    secrets: inherit
+    secrets:
+      COOLIFY_DEPLOY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_B2C_BACKEND_DEV }}
+      COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+
+  deploy-staging:
+    needs: [docker-validate]
+    if: github.ref == 'refs/heads/staging' && github.event_name == 'push'
+    uses: ConferInc/CI-Pipeline/.github/workflows/reusable-cd-deploy.yml@main
+    with:
+      image-name: nutrition-backend
+      context: .
+      dockerfile: Dockerfile
+      build-args: ""
+    secrets:
+      COOLIFY_DEPLOY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_B2C_BACKEND_STAGING }}
+      COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+
+  deploy-prod:
+    needs: [docker-validate]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    uses: ConferInc/CI-Pipeline/.github/workflows/reusable-cd-deploy.yml@main
+    with:
+      image-name: nutrition-backend
+      context: .
+      dockerfile: Dockerfile
+      build-args: ""
+    secrets:
+      COOLIFY_DEPLOY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_B2C_BACKEND_PROD }}
+      COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- CI triggers include develop and staging branches

- New deploy jobs for dev, staging, prod environments
  - deploy-dev uses `COOLIFY_WEBHOOK_B2C_BACKEND_DEV`
  - deploy-staging uses `COOLIFY_WEBHOOK_B2C_BACKEND_STAGING`
  - deploy-prod uses `COOLIFY_WEBHOOK_B2C_BACKEND_PROD`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PRPush["Push/PR to develop/staging/main"]
  CI["CI Pipeline (docker validate)"]
  DevDeploy["deploy-dev job (develop branch)"]
  StagingDeploy["deploy-staging job (staging branch)"]
  ProdDeploy["deploy-prod job (main branch)"]
  PRPush -- "trigger CI" --> CI
  CI -- "on develop" --> DevDeploy
  CI -- "on staging" --> StagingDeploy
  CI -- "on main" --> ProdDeploy
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>b2c_backend-ci.yml</strong><dd><code>Add multi-environment deploy jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/b2c_backend-ci.yml

<ul><li>Expanded CI <code>on</code> triggers to <code>develop</code> and <code>staging</code><br> <li> Renamed <code>deploy</code> job to <code>deploy-dev</code> with develop condition<br> <li> Added <code>deploy-staging</code> and <code>deploy-prod</code> jobs<br> <li> Configured environment-specific <code>COOLIFY_DEPLOY_WEBHOOK_URL</code> secrets</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/30/files#diff-73bcf35ff4b7f16c5fd4bdf20d85a45cffd72a372e4b9c21731f48557943e0b2">+33/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

