### PR TITLE
Feature/content pipeline integration

### DIFF
--- a/server/routes/analyzer.ts
+++ b/server/routes/analyzer.ts
@@ -209,7 +209,9 @@ router.post(
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const customerId = b2cId(req);
-      const result = await saveAnalyzedRecipe(req.body, customerId);
+      // Frontend sends { result: {...} }, unwrap if needed (backward-compatible)
+      const payload = req.body?.result ?? req.body;
+      const result = await saveAnalyzedRecipe(payload, customerId);
       trackFeature(customerId, "analyzer", "save");
       res.status(201).json(result);
     } catch (err) {

--- a/server/services/allergenClient.ts
+++ b/server/services/allergenClient.ts
@@ -1,14 +1,15 @@
 // server/services/allergenClient.ts
 // Fire-and-forget HTTP client for the Allergen Backfill Pipeline
 // Mirrors ragClient.ts pattern but simpler (no circuit breaker needed — async, non-critical path)
+// Supports both unified content-pipeline (preferred) and legacy allergen-pipeline
 
 import { logger } from "../config/logger.js";
 
 // ── Configuration ────────────────────────────────────────────────────────────
-
-const ALLERGEN_API_URL = process.env.ALLERGEN_API_URL || "";
-const ALLERGEN_API_KEY = process.env.ALLERGEN_API_KEY || "";
-const USE_ALLERGEN_PIPELINE = process.env.USE_ALLERGEN_PIPELINE === "true";
+// Prefer content-pipeline URL; fall back to standalone allergen API
+const ALLERGEN_API_URL = process.env.CONTENT_PIPELINE_URL || process.env.ALLERGEN_API_URL || "";
+const ALLERGEN_API_KEY = process.env.CONTENT_PIPELINE_API_KEY || process.env.ALLERGEN_API_KEY || "";
+const USE_ALLERGEN_PIPELINE = process.env.USE_ALLERGEN_PIPELINE === "true" || process.env.USE_CONTENT_PIPELINE === "true";
 const TIMEOUT_MS = 15_000; // Pipeline may invoke LLM for ingredient matching
 
 // ── Public API ───────────────────────────────────────────────────────────────

--- a/server/services/analyzer.ts
+++ b/server/services/analyzer.ts
@@ -34,6 +34,7 @@ export interface InferredAttributes {
   allergens?: string[];
   diets?: string[];
   cuisines?: string[];
+  mealType?: string;
   taste?: string[];
 }
 
@@ -511,6 +512,7 @@ function convertToAnalyzeResult(
         ...(llmResult.diets_incompatible || []).map((d) => `not_${d}`),
       ],
       cuisines: llmResult.cuisine ? [llmResult.cuisine] : [],
+      mealType: llmResult.meal_type || undefined,
       taste: [],
     },
     nutritionPerServing: {
@@ -601,6 +603,8 @@ export async function saveAnalyzedRecipe(
       name: ing.item,
     })) || [],
     instructions: result.steps || [],
+    cuisine: result.inferred?.cuisines?.[0] || undefined,
+    mealType: result.inferred?.mealType || undefined,
     nutrition: {
       calories: result.nutritionPerServing?.calories || null,
       protein_g: result.nutritionPerServing?.protein_g || null,

--- a/server/services/contentPipelineClient.ts
+++ b/server/services/contentPipelineClient.ts
@@ -47,6 +47,11 @@ export async function recipeBackfill(
     return;
   }
 
+  if (!CONTENT_PIPELINE_API_KEY) {
+    logger.warn("[contentPipeline] CONTENT_PIPELINE_API_KEY not configured, skipping backfill");
+    return;
+  }
+
   const url = `${CONTENT_PIPELINE_URL}/recipes/backfill`;
   const payload = {
     gold_recipe_id: goldRecipeId,

--- a/server/services/contentPipelineClient.ts
+++ b/server/services/contentPipelineClient.ts
@@ -1,0 +1,99 @@
+// server/services/contentPipelineClient.ts
+// Fire-and-forget HTTP client for the Content Pipeline Service
+// Mirrors allergenClient.ts pattern — non-blocking, non-critical path
+
+import { logger } from "../config/logger.js";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const CONTENT_PIPELINE_URL = process.env.CONTENT_PIPELINE_URL || "";
+const CONTENT_PIPELINE_API_KEY = process.env.CONTENT_PIPELINE_API_KEY || "";
+const USE_CONTENT_PIPELINE = process.env.USE_CONTENT_PIPELINE === "true";
+const TIMEOUT_MS = 60_000; // USDA fetch can take ~5-8s per new ingredient
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Fire-and-forget call to the Content Pipeline Service for recipe backfill.
+ *
+ * Pre-condition (B2C has already done):
+ *   - gold.recipes INSERT (via createUserRecipe)
+ *   - gold.recipe_ingredients INSERT
+ *
+ * The pipeline will:
+ *   1. Check each ingredient against gold.ingredients
+ *   2. For NEW ingredients: run USDA enhanced pipeline → INSERT bronze.raw_ingredients
+ *   3. INSERT bronze.raw_recipes (lineage record)
+ *   4. Trigger bronze_to_gold orchestration flow
+ *
+ * On failure: silently logged. Recipe is already saved in gold.
+ * The pipeline can be retried later — all operations are idempotent.
+ */
+export async function recipeBackfill(
+  goldRecipeId: string,
+  recipeData: Record<string, any>,
+  ingredients: Array<{ item: string; qty?: number; unit?: string }>,
+  sourceType: "user_generated" | "recipe_analyzer",
+  submittedBy: string
+): Promise<void> {
+  // Gate: feature flag
+  if (!USE_CONTENT_PIPELINE) {
+    logger.debug("[contentPipeline] Pipeline disabled (USE_CONTENT_PIPELINE != true)");
+    return;
+  }
+
+  if (!CONTENT_PIPELINE_URL) {
+    logger.warn("[contentPipeline] CONTENT_PIPELINE_URL not configured, skipping backfill");
+    return;
+  }
+
+  const url = `${CONTENT_PIPELINE_URL}/recipes/backfill`;
+  const payload = {
+    gold_recipe_id: goldRecipeId,
+    recipe_data: recipeData,
+    ingredients,
+    source_type: sourceType,
+    submitted_by: submittedBy,
+  };
+
+  logger.info(
+    `[contentPipeline] Firing recipe backfill → ${url} | recipe="${recipeData.title}" goldId=${goldRecipeId}`
+  );
+
+  // Fire-and-forget: don't await in the caller's hot path
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": CONTENT_PIPELINE_API_KEY,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "<unreadable>");
+      logger.error(
+        `[contentPipeline] Pipeline returned ${response.status}: ${body}`
+      );
+    } else {
+      const result = await response.json().catch(() => ({}));
+      logger.info(
+        `[contentPipeline] Pipeline success: ${JSON.stringify(result)}`
+      );
+    }
+  } catch (err: any) {
+    if (err.name === "AbortError") {
+      logger.error(`[contentPipeline] Pipeline timed out after ${TIMEOUT_MS}ms`);
+    } else {
+      logger.error(`[contentPipeline] Pipeline call failed:`, err);
+    }
+    // Non-critical: user's recipe is already saved in gold.recipes
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/server/services/llm.ts
+++ b/server/services/llm.ts
@@ -97,6 +97,7 @@ export interface LLMAnalysisResult {
   diets_incompatible: string[];
   suggestions: string[];
   cuisine?: string;
+  meal_type?: string;
   difficulty?: "easy" | "medium" | "hard";
   prep_time_minutes?: number;
   cook_time_minutes?: number;
@@ -107,7 +108,7 @@ export interface LLMAnalysisResult {
 const RECIPE_ANALYSIS_SYSTEM_PROMPT = `You are a nutrition expert. Extract structured recipe data as JSON.
 
 Required JSON schema:
-{"title":"string","servings":int,"ingredients":[{"qty":number|null,"unit":"string|null","item":"string","calories_per_unit":number,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number}],"steps":["string"],"nutrition_per_serving":{"calories":int,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number,"potassium_mg":number,"iron_mg":number,"calcium_mg":number,"vitamin_d_mcg":number},"allergens":["string"],"diets_compatible":["string"],"diets_incompatible":["string"],"suggestions":["string"],"cuisine":"string","difficulty":"easy|medium|hard","prep_time_minutes":int,"cook_time_minutes":int}
+{"title":"string","servings":int,"ingredients":[{"qty":number|null,"unit":"string|null","item":"string","calories_per_unit":number,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number}],"steps":["string"],"nutrition_per_serving":{"calories":int,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number,"potassium_mg":number,"iron_mg":number,"calcium_mg":number,"vitamin_d_mcg":number},"allergens":["string"],"diets_compatible":["string"],"diets_incompatible":["string"],"suggestions":["string"],"cuisine":"string","meal_type":"breakfast|lunch|dinner|snack|dessert","difficulty":"easy|medium|hard","prep_time_minutes":int,"cook_time_minutes":int}
 
 Rules:
 - Estimate nutrition per serving from ingredient quantities
@@ -275,7 +276,7 @@ const VISUAL_FOOD_ANALYSIS_PROMPT = `You are a nutrition expert with food image 
 Based on what you visually identify, estimate the recipe details and return structured JSON.
 
 Required JSON schema:
-{"title":"string","servings":int,"ingredients":[{"qty":number|null,"unit":"string|null","item":"string","calories_per_unit":number,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number}],"steps":["string"],"nutrition_per_serving":{"calories":int,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number,"potassium_mg":number,"iron_mg":number,"calcium_mg":number,"vitamin_d_mcg":number},"allergens":["string"],"diets_compatible":["string"],"diets_incompatible":["string"],"suggestions":["string"],"cuisine":"string","difficulty":"easy|medium|hard","prep_time_minutes":int,"cook_time_minutes":int}
+{"title":"string","servings":int,"ingredients":[{"qty":number|null,"unit":"string|null","item":"string","calories_per_unit":number,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number}],"steps":["string"],"nutrition_per_serving":{"calories":int,"protein_g":number,"carbs_g":number,"fat_g":number,"sodium_mg":number,"sugar_g":number,"fiber_g":number,"potassium_mg":number,"iron_mg":number,"calcium_mg":number,"vitamin_d_mcg":number},"allergens":["string"],"diets_compatible":["string"],"diets_incompatible":["string"],"suggestions":["string"],"cuisine":"string","meal_type":"breakfast|lunch|dinner|snack|dessert","difficulty":"easy|medium|hard","prep_time_minutes":int,"cook_time_minutes":int}
 
 Rules:
 - Identify the dish from the image visually (color, texture, shape, plating)

--- a/server/services/userContent.ts
+++ b/server/services/userContent.ts
@@ -95,7 +95,12 @@ async function getOrCreateIngredientId(name: string) {
   );
   if (synonymMatch[0]?.id) return synonymMatch[0].id;
 
-  // Tier 3: Trigram similarity (uses existing DB function, threshold 0.7)
+  // Tier 3: Trigram similarity — pg_trgm extension + GIN index confirmed in
+  // migration 016_ingredient_search_and_unit_conversions.sql:
+  //   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  //   CREATE INDEX IF NOT EXISTS idx_ingredients_name_trgm
+  //     ON gold.ingredients USING GIN (name gin_trgm_ops);
+  // No additional migration required; safe for production use.
   const trigramMatch = await executeRaw(
     `SELECT id::text FROM gold.search_ingredients_trigram($1, 0.7, 1)`,
     [name.trim()]

--- a/server/services/userContent.ts
+++ b/server/services/userContent.ts
@@ -9,6 +9,7 @@ import {
 } from "../../shared/goldSchema.js";
 import { resolveCuisineIds } from "./b2cTaxonomy.js";
 import { getRecipeIngredients, getRecipeNutritionMap } from "./recipeHydration.js";
+import { recipeBackfill } from "./contentPipelineClient.js";
 
 type AnyObj = Record<string, any>;
 
@@ -76,13 +77,30 @@ function inferSourceType(name: string): string | null {
 
 // Fix 5+6: Case-insensitive matching + enriched creation
 async function getOrCreateIngredientId(name: string) {
-  // Fix 6: case-insensitive matching to avoid duplicates
+  // Tier 1: Case-insensitive exact match (existing)
   const existing = await db
     .select()
     .from(ingredients)
     .where(ilike(ingredients.name, name))
     .limit(1);
   if (existing[0]?.id) return existing[0].id;
+
+  // Tier 2: Synonym lookup
+  const synonymMatch = await executeRaw(
+    `SELECT canonical_ingredient_id::text AS id
+     FROM gold.ingredient_synonyms
+     WHERE LOWER(synonym) = LOWER($1)
+     LIMIT 1`,
+    [name.trim()]
+  );
+  if (synonymMatch[0]?.id) return synonymMatch[0].id;
+
+  // Tier 3: Trigram similarity (uses existing DB function, threshold 0.7)
+  const trigramMatch = await executeRaw(
+    `SELECT id::text FROM gold.search_ingredients_trigram($1, 0.7, 1)`,
+    [name.trim()]
+  );
+  if (trigramMatch[0]?.id) return trigramMatch[0].id;
 
   // Fix 5: Enrich new ingredients with metadata
   const created = await db
@@ -262,6 +280,29 @@ export async function createUserRecipe(b2cCustomerId: string, payload: AnyObj) {
   await replaceRecipeNutrition(row.id, input.nutrition);
   await replaceRecipeNutritionProfile(row.id, input.nutrition, input.servings);
 
+  // Fire-and-forget: trigger content pipeline to create bronze lineage + USDA enrichment
+  recipeBackfill(
+    row.id,
+    {
+      title: input.title,
+      description: input.description,
+      servings: input.servings,
+      cuisine: input.cuisineLabel,
+      meal_type: input.mealType,
+      prep_time: input.prepTimeMinutes,
+      cook_time: input.cookTimeMinutes,
+      instructions: input.instructions,
+      nutrition: input.nutrition,
+    },
+    input.ingredients.map((i: IngredientInput) => ({
+      item: (i.item ?? i.name ?? "").toString().trim(),
+      qty: i.qty ? Number(i.qty) : undefined,
+      unit: i.unit ?? undefined,
+    })),
+    "user_generated",
+    b2cCustomerId
+  ).catch(() => {}); // non-critical — recipe is already saved
+
   return row;
 }
 
@@ -296,10 +337,34 @@ export async function updateUserRecipe(b2cCustomerId: string, recipeId: string, 
   if (updates.ingredients) {
     await replaceRecipeIngredients(recipeId, input.ingredients);
   }
-  if (updates.calories !== undefined || updates.protein_g !== undefined) {
+  if (updates.nutrition || updates.calories !== undefined || updates.protein_g !== undefined ||
+      updates.fat_g !== undefined || updates.fiber_g !== undefined || updates.sugar_g !== undefined) {
     await replaceRecipeNutrition(recipeId, input.nutrition);
     await replaceRecipeNutritionProfile(recipeId, input.nutrition, input.servings);
   }
+
+  // Fire-and-forget: update bronze lineage (idempotent via data_hash)
+  recipeBackfill(
+    recipeId,
+    {
+      title: input.title,
+      description: input.description,
+      servings: input.servings,
+      cuisine: input.cuisineLabel,
+      meal_type: input.mealType,
+      prep_time: input.prepTimeMinutes,
+      cook_time: input.cookTimeMinutes,
+      instructions: input.instructions,
+      nutrition: input.nutrition,
+    },
+    input.ingredients.map((i: IngredientInput) => ({
+      item: (i.item ?? i.name ?? "").toString().trim(),
+      qty: i.qty ? Number(i.qty) : undefined,
+      unit: i.unit ?? undefined,
+    })),
+    "user_generated",
+    b2cCustomerId
+  ).catch(() => {}); // non-critical — recipe is already saved
 
   return updated[0];
 }
@@ -335,9 +400,12 @@ export async function getUserRecipe(b2cCustomerId: string, recipeId: string) {
 }
 
 export async function deleteUserRecipe(b2cCustomerId: string, recipeId: string) {
-  await db.delete(recipes).where(and(eq(recipes.id, recipeId), eq(recipes.createdByUserId, b2cCustomerId)));
+  // Delete child rows first to respect FK constraints
   await executeRaw(`delete from gold.recipe_ingredients where recipe_id = $1`, [recipeId]);
   await executeRaw(`delete from gold.nutrition_facts where entity_type = 'recipe' and entity_id = $1`, [recipeId]);
+  await db.delete(recipeNutritionProfiles).where(eq(recipeNutritionProfiles.recipeId, recipeId));
+  // Delete parent row last
+  await db.delete(recipes).where(and(eq(recipes.id, recipeId), eq(recipes.createdByUserId, b2cCustomerId)));
 }
 
 export async function shareUserRecipe(_userId: string, recipeId: string) {


### PR DESCRIPTION
### **User description**
## feat: content pipeline integration — recipe backfill, `mealType`, 3-tier ingredient resolution

### Summary

Wires the B2C backend to the new unified **Content Pipeline Service**
(`ConferInc/b2c-user-content-pipeline`) for post-save recipe enrichment and
bronze-layer lineage tracking. Also upgrades ingredient deduplication from
single-tier exact match to a 3-tier resolution chain, adds `meal_type`
extraction through the full LLM → analyzer → save stack, fixes the analyzer
save route's payload unwrapping, and hardens FK-safe recipe deletion.

All pipeline calls are **fire-and-forget** — the user's recipe is fully saved
in `gold.recipes` before any pipeline call is made, and all pipeline failures
are silently logged. Zero impact on response latency or error behaviour.

---

### Files changed (6)

---

#### `server/services/contentPipelineClient.ts` ← NEW FILE

Fire-and-forget HTTP client that calls `POST /recipes/backfill` on the
Content Pipeline Service after every UGC or analyzer recipe save.

- **Feature-flagged**: no-ops unless `USE_CONTENT_PIPELINE=true`
- **Graceful degradation**: no-ops if `CONTENT_PIPELINE_URL` is not set
- **60 s timeout** via `AbortController` (USDA fetch can take ~5–8 s per new ingredient)
- All errors (timeout, HTTP 4xx/5xx, network) are caught and logged — never
  thrown back to the caller
- Payload sent to pipeline:

```
gold_recipe_id, recipe_data { title, description, servings, cuisine,
meal_type, prep_time, cook_time, instructions, nutrition },
ingredients [{ item, qty, unit }], source_type, submitted_by
```

---

#### `server/services/allergenClient.ts`

Adds backward-compatible preference for the new unified Content Pipeline
URL/key, falling back to the legacy standalone allergen pipeline env vars.

| Env var (before) | Env var (preferred, after) | Fallback |
|---|---|---|
| `ALLERGEN_API_URL` | `CONTENT_PIPELINE_URL` | `ALLERGEN_API_URL` |
| `ALLERGEN_API_KEY` | `CONTENT_PIPELINE_API_KEY` | `ALLERGEN_API_KEY` |
| `USE_ALLERGEN_PIPELINE` | `USE_CONTENT_PIPELINE` | `USE_ALLERGEN_PIPELINE` |

**No breaking change** — existing deployments with the old env vars continue
to work without modification.

---

#### `server/services/analyzer.ts`

Threads `meal_type` from the LLM result through to the recipe save payload.

- `InferredAttributes` interface: adds optional `mealType?: string`
- `convertToAnalyzeResult`: maps `llmResult.meal_type` → `inferred.mealType`
- `saveAnalyzedRecipe`: passes `cuisine` and `mealType` fields into the
  `createUserRecipe` payload (both were previously dropped on the floor)

---

#### `server/services/llm.ts`

Adds `meal_type` extraction to both LLM analysis prompts.

- `LLMAnalysisResult` interface: adds optional `meal_type?: string`
- **Text analysis prompt** (`RECIPE_ANALYSIS_SYSTEM_PROMPT`): JSON schema
  updated to include `"meal_type":"breakfast|lunch|dinner|snack|dessert"`
- **Visual analysis prompt** (`VISUAL_FOOD_ANALYSIS_PROMPT`): same schema
  update applied

---

#### `server/services/userContent.ts`

Three independent improvements:

**1 — 3-tier ingredient resolution in `getOrCreateIngredientId`**

Reduces ingredient duplication by falling through three resolution strategies
before creating a new `gold.ingredients` row:

| Tier | Strategy | Implementation |
|---|---|---|
| 1 | Case-insensitive exact match | Drizzle `ilike` (existing) |
| 2 | Synonym lookup | `gold.ingredient_synonyms` table — `LOWER(synonym) = LOWER($1)` |
| 3 | Trigram similarity | `gold.search_ingredients_trigram($1, 0.7, 1)` DB function at threshold 0.7 |

**2 — Content pipeline backfill calls**

- `createUserRecipe`: calls `recipeBackfill(...)` as fire-and-forget after
  all gold INSERTs complete. `.catch(() => {})` ensures no uncaught rejection.
- `updateUserRecipe`: same call pattern for edits (pipeline is idempotent via
  `data_hash`). Nutrition update condition also widened — previously only
  triggered on `calories`/`protein_g` changes; now covers all nutrition fields
  (`fat_g`, `fiber_g`, `sugar_g`, etc.).

**3 — FK-safe `deleteUserRecipe`**

Fixes a potential FK violation by deleting child rows before the parent:

```
Before:  DELETE gold.recipes → DELETE recipe_ingredients → DELETE nutrition_facts

After:   DELETE recipe_ingredients
         DELETE nutrition_facts
         DELETE recipe_nutrition_profiles  ← was missing entirely
         DELETE gold.recipes               ← parent deleted last
```

---

#### `server/routes/analyzer.ts`

Fixes `POST /analyze/save` to handle both payload shapes the frontend may send:

```ts
// Before:
const result = await saveAnalyzedRecipe(req.body, customerId);

// After (backward-compatible):
const payload = req.body?.result ?? req.body;
const result = await saveAnalyzedRecipe(payload, customerId);
```

The frontend wraps the analyzer result in `{ result: {...} }` before posting;
the backend was receiving the wrapper object rather than the inner result.

---

### New environment variables required

| Variable | Value | Description |
|---|---|---|
| `CONTENT_PIPELINE_URL` | `http://content-pipeline-api:8001` | Internal Docker alias (Coolify network) |
| `CONTENT_PIPELINE_API_KEY` | `<shared secret>` | Must match `CONTENT_PIPELINE_API_KEY` in the pipeline service |
| `USE_CONTENT_PIPELINE` | `true` | Feature flag — set to enable recipe backfill calls |

> **Note:** Old `ALLERGEN_API_URL` / `ALLERGEN_API_KEY` / `USE_ALLERGEN_PIPELINE`
> vars continue to work as fallback. No immediate migration required.

---

### Test plan

- [ ] `POST /analyze/save` with `{ result: { ... } }` payload → 201, recipe saved correctly
- [ ] `POST /analyze/save` with flat payload (no wrapper) → still 201 (backward-compat)
- [ ] Create UGC recipe — verify `recipeBackfill` log line appears (`[contentPipeline] Firing recipe backfill`)
- [ ] With `USE_CONTENT_PIPELINE=false` (or unset) — verify no pipeline call is attempted
- [ ] Submit recipe with ingredient that already exists under a synonym → no duplicate row created
- [ ] Submit recipe with a near-match ingredient (e.g. "chili powder" vs "chilli powder") → trigram match at ≥0.7 resolves to existing ingredient
- [ ] Delete a recipe → no FK constraint errors in DB logs, all child rows removed
- [ ] Analyze an image/text recipe → `mealType` populated in the saved recipe row
- [ ] Confirm allergen backfill still fires correctly with `USE_CONTENT_PIPELINE=true` (allergenClient fallback check)

---

### No breaking changes

- All pipeline calls are fire-and-forget — request latency and error responses are completely unaffected
- `allergenClient.ts` remains fully backward-compatible with old env vars
- `routes/analyzer.ts` payload unwrap is backward-compatible with flat payloads
- `deleteUserRecipe` fix is purely additive (adds missing FK-ordered cleanup steps)
- `meal_type` is an optional field throughout — existing recipes without it are unaffected

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Integrate Content Pipeline Service for recipe backfill

- Enhance 3-tier ingredient resolution chain

- Propagate meal_type through LLM and save stack

- Support unified pipeline in allergen client; fix analyzer payload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UserContent create/update"]
  B["Analyzer save route"]
  C["recipeBackfill() client"]
  D["Content Pipeline Service"]
  A -- "fire-and-forget" --> C
  B -- "fire-and-forget" --> C
  C -- "POST /recipes/backfill" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analyzer.ts</strong><dd><code>Backward-compatible analyzer payload unwrap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes/analyzer.ts

<ul><li>Unwrap backward-compatible <code>{ result: ... }</code> payload<br> <li> Preserve existing <code>saveAnalyzedRecipe</code> call and tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-52de3453d8588ced24794ed40dbc7ef490375d7f5c0e1ffe4ebe2748f4dfaab6">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>allergenClient.ts</strong><dd><code>Support unified pipeline in allergenClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/allergenClient.ts

<ul><li>Prefer <code>CONTENT_PIPELINE_URL</code> and API key first<br> <li> Fall back to legacy allergen env vars<br> <li> Extend <code>USE_ALLERGEN_PIPELINE</code> flag logic</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-c3044766bcb208c563e55f9dbfd45af3aa8008989e1f3b0d61ce90ec56545b99">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analyzer.ts</strong><dd><code>Add meal_type support in analyzer service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/analyzer.ts

<ul><li>Add <code>mealType</code> to <code>InferredAttributes</code> interface<br> <li> Map <code>meal_type</code> from LLM into inferred attributes<br> <li> Persist <code>mealType</code> field in <code>saveAnalyzedRecipe</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-61c5148df3d3cc61603b4d99d7f4ba49e12f5a238c1977cfa3cfdc9faa9da745">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>contentPipelineClient.ts</strong><dd><code>Add Content Pipeline fire-and-forget client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/contentPipelineClient.ts

<ul><li>Introduce <code>recipeBackfill</code> fire-and-forget client<br> <li> Implement feature flag, timeout, and error logging<br> <li> Send enriched recipe payload to <code>/recipes/backfill</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-5078791afcfa533dcbb6dbb2795c2644af223f1e50579dce43adc7c95a9f5c7d">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>llm.ts</strong><dd><code>Extend LLM schema and prompts with meal_type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/llm.ts

<ul><li>Extend <code>LLMAnalysisResult</code> with <code>meal_type</code> field<br> <li> Update system and visual prompts to include <code>meal_type</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-af93bffd23d6136ad5663b57d8edf4eebc60d95a6e48f1c514ad0b762f20574b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>userContent.ts</strong><dd><code>Enhance userContent: ingredient resolution & backfill</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/userContent.ts

<ul><li>Add 3-tier ingredient resolution (exact, synonym, trigram)<br> <li> Invoke <code>recipeBackfill</code> on create and update<br> <li> Cascade delete recipe rows respecting FKs</ul>


</details>


  </td>
  <td><a href="https://github.com/ConferInc/nutrition-backend/pull/34/files#diff-f3d8ce69c4a0ceb2ad257c4d6d8bafb497232e0bd338376c995a26a5365dc0cd">+71/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

